### PR TITLE
Make it run with Django 2.0

### DIFF
--- a/easyaudit/migrations/0001_initial.py
+++ b/easyaudit/migrations/0001_initial.py
@@ -23,7 +23,7 @@ class Migration(migrations.Migration):
                 ('object_repr', models.CharField(max_length=255, null=True, blank=True)),
                 ('object_json_repr', models.TextField(null=True, blank=True)),
                 ('datetime', models.DateTimeField(auto_now_add=True)),
-                ('content_type', models.ForeignKey(to='contenttypes.ContentType')),
+                ('content_type', models.ForeignKey(to='contenttypes.ContentType', on_delete=models.CASCADE)),
                 ('user', models.ForeignKey(on_delete=django.db.models.deletion.SET_NULL, blank=True, to=settings.AUTH_USER_MODEL, null=True)),
             ],
             options={

--- a/easyaudit/models.py
+++ b/easyaudit/models.py
@@ -21,7 +21,7 @@ class CRUDEvent(models.Model):
 
     event_type = models.SmallIntegerField(choices=TYPES)
     object_id = models.IntegerField()  # we should try to allow other ID types
-    content_type = models.ForeignKey(ContentType)
+    content_type = models.ForeignKey(ContentType, on_delete=models.CASCADE)
     object_repr = models.CharField(max_length=255, null=True, blank=True)
     object_json_repr = models.TextField(null=True, blank=True)
     user = models.ForeignKey(settings.AUTH_USER_MODEL, null=True, blank=True, on_delete=models.SET_NULL)


### PR DESCRIPTION
`on_delete` on ForeignKeys is required since Django 2.0, see https://docs.djangoproject.com/en/1.11/ref/models/fields/#foreignkey